### PR TITLE
now compiles with ghc 8.X (tested on 8.4.4)

### DIFF
--- a/src/Pretty.lhs
+++ b/src/Pretty.lhs
@@ -175,7 +175,12 @@ module Pretty (
         render, fullRender
   ) where
 
+
+import Prelude hiding ((<>))
+
 -- Don't import Util( assertPanic ) because it makes a loop in the module structure
+
+
 
 infixl 6 <>
 infixl 6 <+>

--- a/src/RuleUtils.hs
+++ b/src/RuleUtils.hs
@@ -6,6 +6,8 @@ import Pretty
 import DataP (Statement(..),Data(..),Type(..),Name,Var,Class,
 		Body(..),Constructor)
 
+import Prelude hiding ((<>))
+
 -- Rule Declarations
 
 type Tag = String

--- a/src/Rules/BitsBinary.hs
+++ b/src/Rules/BitsBinary.hs
@@ -3,6 +3,7 @@ module Rules.BitsBinary(rules) where
 
 import Data.List (intersperse)
 import RuleUtils -- useful to have a look at this too
+import Prelude hiding ((<>))
 
 rules = [
     ("BitsBinary", userRuleBinary, "Binary", "bit based binary encoding of terms", Nothing)

--- a/src/Rules/FunctorM.hs
+++ b/src/Rules/FunctorM.hs
@@ -3,6 +3,7 @@ module Rules.FunctorM (rules) where
 
 import Data.List
 import RuleUtils
+import Prelude hiding ((<>))
 
 rules = [
     ("FunctorM", userRuleFunctorM, "Generics", "derive reasonable fmapM implementation", Nothing),

--- a/src/Rules/Generic.hs
+++ b/src/Rules/Generic.hs
@@ -4,7 +4,7 @@ module Rules.Generic(rules) where
 -- import StandardRules
 import RuleUtils
 import Data.List(intersperse)
-
+import Prelude hiding ((<>))
 
 rules :: [RuleDef]
 rules =  [

--- a/src/Rules/Monoid.hs
+++ b/src/Rules/Monoid.hs
@@ -2,7 +2,7 @@
 module Rules.Monoid (rules) where
 
 import RuleUtils
-
+import Prelude hiding ((<>))
 rules = [
     ("Monoid", userRuleMonoid, "Generics", "derive reasonable Data.Monoid implementation", Nothing)
     ]

--- a/src/Rules/Standard.hs
+++ b/src/Rules/Standard.hs
@@ -3,7 +3,7 @@ module Rules.Standard(rules) where
 import RuleUtils
 import Data.List
 import GenUtil
-
+import Prelude hiding ((<>))
 
 --- Add Rules Below Here ----------------------------------------------------
 

--- a/src/Rules/Xml.hs
+++ b/src/Rules/Xml.hs
@@ -3,6 +3,7 @@ module Rules.Xml(rules) where
 
 import Data.List (nub,sortBy)
 import RuleUtils -- useful to have a look at this too
+import Prelude hiding ((<>))
 
 rules :: [RuleDef]
 rules =


### PR DESCRIPTION
This is the most lazy solution, instead of this I could implement the Semigroup instance everywhere, but it would require more time, to check if every implementation of the (<>) operation is actually associative